### PR TITLE
Minor changes to mark notifications as read

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
+++ b/app/src/main/java/fr/free/nrw/commons/mwapi/MediaWikiApi.java
@@ -85,7 +85,7 @@ public interface MediaWikiApi {
     List<Notification> getNotifications() throws IOException;
 
     @NonNull
-    CustomApiResult markNotificationAsRead(Notification notification) throws IOException;
+    boolean markNotificationAsRead(Notification notification) throws IOException;
 
     @NonNull
     Observable<String> searchTitles(String title, int searchCatsLimit);

--- a/app/src/main/java/fr/free/nrw/commons/notification/Notification.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/Notification.java
@@ -24,4 +24,18 @@ public class Notification {
         this.dateWithYear = dateWithYear;
         this.notificationId=notificationId;
     }
+
+    @Override
+    public String toString() {
+        return "Notification" +
+                "notificationType='" + notificationType + '\'' +
+                ", notificationText='" + notificationText + '\'' +
+                ", date='" + date + '\'' +
+                ", description='" + description + '\'' +
+                ", link='" + link + '\'' +
+                ", iconUrl='" + iconUrl + '\'' +
+                ", dateWithYear=" + dateWithYear +
+                ", notificationId='" + notificationId + '\'' +
+                '}';
+    }
 }

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationActivity.java
@@ -104,10 +104,7 @@ public class NotificationActivity extends NavigationBaseActivity {
 
                     builder.setPositiveButton("REMOVE", (dialog, which) -> {
 
-                        Observable.fromCallable(() -> {
-                             controller.markAsRead(notificationList.get(position));
-                             return true;
-                        })
+                        Observable.fromCallable(() -> controller.markAsRead(notificationList.get(position)))
                                 .subscribeOn(Schedulers.io())
                                 .observeOn(AndroidSchedulers.mainThread())
                                 .subscribe(result -> {

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationController.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationController.java
@@ -37,10 +37,6 @@ public class NotificationController {
         return new ArrayList<>();
     }
     public boolean markAsRead(Notification notification) throws IOException{
-        /*if (mediaWikiApi.markNotificationAsRead(notification)=="success"){
-            return true;
-        } else return false;*/
-        mediaWikiApi.markNotificationAsRead(notification);
-        return true;
+        return mediaWikiApi.markNotificationAsRead(notification);
     }
 }

--- a/app/src/main/java/fr/free/nrw/commons/notification/NotificationUtils.java
+++ b/app/src/main/java/fr/free/nrw/commons/notification/NotificationUtils.java
@@ -74,6 +74,11 @@ public class NotificationUtils {
         return NotificationType.handledValueOf(type);
     }
 
+    public static String getNotificationId(Node document) {
+        Element element = (Element) document;
+        return element.getAttribute("id");
+    }
+
     public static List<Notification> getNotificationsFromBundle(Context context, Node document) {
         Element bundledNotifications = getBundledNotifications(document);
         NodeList childNodes = bundledNotifications.getChildNodes();
@@ -154,7 +159,8 @@ public class NotificationUtils {
                 notificationText = getWelcomeMessage(context, document);
                 break;
         }
-        return new Notification(type, notificationText, getTimestamp(document), description, link, iconUrl, getTimestampWithYear(document));
+        return new Notification(type, notificationText, getTimestamp(document), description, link, iconUrl, getTimestampWithYear(document),
+                getNotificationId(document));
     }
 
     private static String getNotificationText(Node document) {


### PR DESCRIPTION
@vanshikaarora Great work with the dismiss notification feature. 

Changes I did: 
- add `notificationID` param
- fix API call ie make it `POST` API.
- minor changes to make the basic things work. 

There are some issues that I noticed. 
- use string res
- when marking as read fails, the notification shows as blank
- showing a dialog seems to be obstructive. On swiping left, we can show an option to mark as read. You find examples in apps like whatsapp/Gmail